### PR TITLE
Add Node Label to Scrape Config

### DIFF
--- a/controllers/scrapeconfigs/scrapeconfigs.go
+++ b/controllers/scrapeconfigs/scrapeconfigs.go
@@ -134,6 +134,7 @@ func SetScrapeConfig(scrapeConfig parcav1alpha1.ParcaScrapeConfig, pods []corev1
 				"namespace": scrapeConfig.Namespace,
 				"pod":       pod.Name,
 				"container": container,
+				"node":      pod.Spec.NodeName,
 			},
 		})
 


### PR DESCRIPTION
This commit adds a new label "node" to the generated scrape config for a Pod in the Parca configuration.