### PR TITLE
Rename Configuration Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ helm upgrade --install parca-operator ricoberger/parca-operator
 
 Make sure that you set the following environment variables for the Parca Operator:
 
-- `PARCA_OPERATOR_CONFIG`: The path to the configration file for Parca. This file is used as base for the generated Parca configration and should contain you `object_storage` configuration.
-- `PARCA_OPERATOR_CONFIG_NAME`: The name of secret which should be generated. The secret contains a `parca.yaml` key with the generated configuration for Parca.
-- `PARCA_OPERATOR_CONFIG_NAMESPACE`: The namespace of secret which should be generated. The secret contains a `parca.yaml` key with the generated configuration for Parca.
+- `PARCA_SCRAPECONFIG_RECONCILIATION_INTERVAL`: The reconciliation interval for the `ParcaScrapeConfig` controller. If this value is not set the `ParcaScrapeConfig` CRs will be reconciled every 5 minutes. This must be a value which can be parsed via the [`ParseDuration`](https://pkg.go.dev/time#ParseDuration) function.
+- `PARCA_SCRAPECONFIG_BASE_CONFIG`: The path to the configration file for Parca. This file is used as base for the generated Parca configration and should contain you `object_storage` configuration.
+- `PARCA_SCRAPECONFIG_FINAL_CONFIG_NAME`: The name of secret which should be generated. The secret contains a `parca.yaml` key with the generated configuration for Parca.
+- `PARCA_SCRAPECONFIG_FINAL_CONFIG_NAMESPACE`: The namespace of secret which should be generated. The secret contains a `parca.yaml` key with the generated configuration for Parca.
 
 ## API Reference
 

--- a/charts/parca-operator/Chart.yaml
+++ b/charts/parca-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.0"
+appVersion: "v0.2.0"

--- a/charts/parca-operator/values.yaml
+++ b/charts/parca-operator/values.yaml
@@ -112,11 +112,13 @@ env:
   ## The following environment variables are required for the Parca Operator to read the base configration and to create
   ## the final configration for Parca:
   ##
-  - name: PARCA_OPERATOR_CONFIG
+  - name: PARCA_SCRAPECONFIG_RECONCILIATION_INTERVAL
+    value: 5m
+  - name: PARCA_SCRAPECONFIG_BASE_CONFIG
     value: /etc/parca/parca.yaml
-  - name: PARCA_OPERATOR_CONFIG_NAME
+  - name: PARCA_SCRAPECONFIG_FINAL_CONFIG_NAME
     value: parca-generated
-  - name: PARCA_OPERATOR_CONFIG_NAMESPACE
+  - name: PARCA_SCRAPECONFIG_FINAL_CONFIG_NAMESPACE
     value: parca
 
 ## Specify additional labels and annotations for the created Pods.

--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ func init() {
 
 func main() {
 	var metricsAddr string
-	var enableLeaderElection bool
 	var probeAddr string
+	var enableLeaderElection bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")


### PR DESCRIPTION
This commit renames the existing environment variables used to configure the Parca Operator. The environment variables now follow the following schema: "PARCA_CONTROLLER-NAME_XYZ". This should improve the configuration of the operator when we add additional controllers.

This commit also introduces a new environment variable "PARCA_SCRAPECONFIG_RECONCILIATION_INTERVAL" which can be used to set the reconciliation interval for the ParcaScrapeConfigs CRs. By default the will be reconciled every 5 minutes.