### PR TITLE
Rename "scrapeconfigs" Package to "parcascrapeconfig"

### DIFF
--- a/controllers/parcascrapeconfig/parcascrapeconfig.go
+++ b/controllers/parcascrapeconfig/parcascrapeconfig.go
@@ -1,4 +1,4 @@
-package scrapeconfigs
+package parcascrapeconfig
 
 import (
 	"context"

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 
 	parcav1alpha1 "github.com/ricoberger/parca-operator/api/v1alpha1"
 	"github.com/ricoberger/parca-operator/controllers"
-	"github.com/ricoberger/parca-operator/controllers/scrapeconfigs"
+	"github.com/ricoberger/parca-operator/controllers/parcascrapeconfig"
 
 	//+kubebuilder:scaffold:imports
 
@@ -47,7 +47,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	err := scrapeconfigs.Init()
+	err := parcascrapeconfig.Init()
 	if err != nil {
 		setupLog.Error(err, "Failed to initialize Parca configuration.")
 		os.Exit(1)


### PR DESCRIPTION
The "scrapeconfigs" package was renamed to "parcascrapeconfig" to follow the naming of the controller.