### PR TITLE
Fix Config Generation when Pod has no IP Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ This Makefile target will invoke controller-gen to generate the CRD manifests at
 Deploy the CRD and run the operator locally with the default Kubernetes config file present at `$HOME/.kube/config`:
 
 ```sh
-export PARCA_OPERATOR_CONFIG=parca.yaml
-export PARCA_OPERATOR_CONFIG_NAME=parca-generated
-export PARCA_OPERATOR_CONFIG_NAMESPACE=parca
+export PARCA_SCRAPECONFIG_RECONCILIATION_INTERVAL=1m
+export PARCA_SCRAPECONFIG_BASE_CONFIG=parca.yaml
+export PARCA_SCRAPECONFIG_FINAL_CONFIG_NAME=parca-generated
+export PARCA_SCRAPECONFIG_FINAL_CONFIG_NAMESPACE=parca
 
 make run
 ```


### PR DESCRIPTION
When a Pod was already created, but doesn't had an IP address assigned yet, the configuration only contained the port number instead of the full address of the Pod. We are no checking that the Pod has an IP address assigned and if this is not the case we skip the Pod.

We also improved the update logic of the generated secret with the Parca configuration. Therefor we are checking the the list of Pod IPs is not empty and not equal to the list of Pod IPs saved in the status field of the ParcaScrapeConfig CR. Only when the Pod IPs are not equal to the saved list of Pod IPs we will update the configuration. For all other cases we skip the update.