### PR TITLE
Fix Example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ spec:
       app: parca-server
   port: 7070
   scrapeConfig:
-    scrape_interval: 60s
-    scrape_timeout: 45s
+    scrape_interval: 45s
+    scrape_timeout: 60s
 ```
 
 </details>


### PR DESCRIPTION
Fix the `ParcaScrapeConfig` example shown in the readme. The `scrape_interval` must always be lower then the `scrape_timeout`.