### PR TITLE
Remove Pods from ClusterRole

### DIFF
--- a/charts/parca-operator/Chart.yaml
+++ b/charts/parca-operator/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: parca-operator
 description: Deploy and Operator Parca
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "v0.5.0"

--- a/charts/parca-operator/templates/clusterrole.yaml
+++ b/charts/parca-operator/templates/clusterrole.yaml
@@ -7,21 +7,10 @@ metadata:
     {{- include "parca-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - ""
     resources:
       - configmaps
+      - secrets
     verbs:
       - create
       - delete
@@ -38,21 +27,9 @@ rules:
       - create
       - patch
   - apiGroups:
-      - ""
+      - coordination.k8s.io
     resources:
-      - pods
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
+      - leases
     verbs:
       - create
       - delete

--- a/internal/controller/parcascrapeconfig_controller.go
+++ b/internal/controller/parcascrapeconfig_controller.go
@@ -35,7 +35,6 @@ type ParcaScrapeConfigReconciler struct {
 //+kubebuilder:rbac:groups=parca.ricoberger.de,resources=parcascrapeconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=parca.ricoberger.de,resources=parcascrapeconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=parca.ricoberger.de,resources=parcascrapeconfigs/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
The operator doesn't need the permissions to interact with Pods,
Therefore the permissions were removed and the ClusterRole was
regenerated using the `make generate` and `make manifests` commands.
